### PR TITLE
refine ui with gradient and airy layout

### DIFF
--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -14,7 +14,7 @@ export default function Catalog(){
   return (
     <main>
       <Nav />
-      <section className="mx-auto max-w-[1200px] px-6 pt-28 pb-16">
+      <section className="mx-auto max-w-[1200px] px-6 pt-32 pb-24">
         <h1 className="font-serif text-4xl text-gyokuro">Catalog</h1>
         <p className="text-black/70 mt-2">Wholesale SKUs with clear pack sizes, MOQs and tiered pricing.</p>
         <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,13 +8,19 @@
   --ink:#1A1D1F; --kintsugi:#B88A44; --shadow:10,20,15;
 }
 
-html, body { height: 100%; background: var(--bg-rice); color: #1A1D1F; }
+html, body {
+  height: 100%;
+  /* Subtle vertical gradient for a lighter, airier canvas */
+  background: linear-gradient(to bottom, var(--bg-rice), var(--mist));
+  color: var(--ink);
+}
 
 .glass{
-  background: rgba(255,255,255,.6);
+  /* Transparent gradient panel used for nav and cards */
+  background: linear-gradient(to bottom, rgba(255,255,255,.65), rgba(255,255,255,.4));
   backdrop-filter: blur(14px);
-  border:1px solid rgba(30,61,50,.08);
-  box-shadow:0 6px 24px rgba(var(--shadow),.08);
+  border:1px solid rgba(30,61,50,.06);
+  box-shadow:0 6px 24px rgba(var(--shadow),.06);
 }
 
 .focus-ring:focus-visible{

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -4,7 +4,7 @@ export default function HowItWorks(){
   return (
     <main>
       <Nav />
-      <section className="mx-auto max-w-[1200px] px-6 pt-28 pb-24">
+      <section className="mx-auto max-w-[1200px] px-6 pt-32 pb-24">
         <h1 className="font-serif text-4xl text-gyokuro">How it works</h1>
         <ol className="mt-6 space-y-4 text-black/80">
           <li><strong>Request access</strong> — Tell us about your business for wholesale pricing.</li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,13 +17,13 @@ export default function Home() {
     <main>
       <Nav />
       <Hero />
-      <section className="mx-auto max-w-[1200px] px-6 pb-16">
+      <section className="mx-auto max-w-[1200px] px-6 py-24">
         <h2 className="font-serif text-3xl text-gyokuro">Wholesale Catalog (preview)</h2>
         <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6">
           {products.map(p => <ProductCard key={p.sku} product={p} />)}
         </div>
       </section>
-      <section className="mx-auto max-w-[1200px] px-6 pb-24">
+      <section className="mx-auto max-w-[1200px] px-6 py-24">
         <h2 className="font-serif text-3xl text-gyokuro">Pricing & MOQ</h2>
         <div className="mt-6">
           <PricingTable rows={[
@@ -34,7 +34,7 @@ export default function Home() {
           <p className="text-xs text-black/60 mt-3">Values are placeholders—replace with your real price lists per segment/region.</p>
         </div>
       </section>
-      <footer className="py-10 text-center text-sm text-black/60">© {new Date().getFullYear()} Yūzen Matcha</footer>
+      <footer className="py-16 text-center text-sm text-black/60">© {new Date().getFullYear()} Yūzen Matcha</footer>
     </main>
   );
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -10,7 +10,7 @@ export default function Pricing(){
   return (
     <main>
       <Nav />
-      <section className="mx-auto max-w-[1200px] px-6 pt-28 pb-16">
+      <section className="mx-auto max-w-[1200px] px-6 pt-32 pb-24">
         <h1 className="font-serif text-4xl text-gyokuro">Pricing & MOQ</h1>
         <p className="text-black/70 mt-2">Transparent tiers and lead times. Replace with your own data.</p>
         <div className="mt-8">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,11 +4,12 @@ import type { Route } from 'next';
 
 export default function Hero(){
   return (
-    <section className="relative pt-28 pb-16">
-      <div className="absolute inset-0 -z-10">
-        <Image src="/hero.svg" alt="" fill priority className="object-cover opacity-80"/>
+    <section className="relative overflow-hidden pt-32 pb-24">
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        <Image src="/hero.svg" alt="" fill priority className="object-cover opacity-60"/>
+        <div className="absolute inset-0 bg-gradient-to-b from-white/80 via-white/50 to-transparent" />
       </div>
-      <div className="mx-auto max-w-[1200px] px-6 grid md:grid-cols-2 items-center gap-10">
+      <div className="mx-auto max-w-[1200px] px-6 grid md:grid-cols-2 items-center gap-12">
         <div>
           <h1 className="font-serif text-5xl md:text-6xl leading-tight text-gyokuro">Ceremonial-grade performance, at scale.</h1>
           <p className="mt-4 text-lg text-black/70 max-w-[48ch]">Matcha for cafes, hotels, and craft kitchens—sourced with precision, stone-milled with care.</p>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -13,7 +13,11 @@ export default function Nav(){
   },[]);
 
   return (
-    <header className={`fixed inset-x-0 top-0 z-50 transition ${scrolled ? 'glass' : 'bg-transparent'}`}>
+    <header
+      className={`fixed inset-x-0 top-0 z-50 transition backdrop-blur-md ${
+        scrolled ? 'glass' : 'bg-gradient-to-b from-white/60 to-transparent'
+      }`}
+    >
       <div className="mx-auto max-w-[1200px] px-6 py-3 flex items-center justify-between">
         <Link href="/" className="font-serif text-xl">Yūzen Matcha</Link>
         <nav className="hidden md:flex gap-8 text-sm">

--- a/components/PricingTable.tsx
+++ b/components/PricingTable.tsx
@@ -2,7 +2,7 @@ type Row = { qty: string; unit: string; unitPrice: string; margin: string; leadT
 
 export default function PricingTable({ rows }: { rows: Row[] }){
   return (
-    <div className="overflow-x-auto rounded-2xl border border-black/5 bg-white shadow-soft">
+    <div className="overflow-x-auto rounded-2xl glass">
       <table className="w-full text-sm">
         <thead className="bg-mist/50">
           <tr className="[&>th]:text-left [&>th]:py-3 [&>th]:px-4">

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -9,7 +9,7 @@ export type Product = {
 
 export default function ProductCard({ product }: { product: Product }){
   return (
-    <article className="rounded-2xl border border-black/5 bg-white p-5 shadow-sm hover:shadow-md transition">
+    <article className="rounded-2xl glass p-5 shadow-sm hover:shadow-md transition">
       <div className="flex items-start justify-between">
         <h3 className="font-medium">{product.name} | SKU {product.sku}</h3>
         <span className="text-[11px] rounded-full px-2 py-1 bg-mist">MOQ {product.moq}</span>


### PR DESCRIPTION
## Summary
- add subtle background gradient and transparent glass panels for premium feel
- expand spacing and hero overlay for airy minimal layout
- apply glass styling to product cards and pricing table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62719d3a08326a413a0c5f3ac62f4