### PR TITLE
Refine Yūzen Matcha wholesale UI with airy gradients

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,13 +8,17 @@
   --ink:#1A1D1F; --kintsugi:#B88A44; --shadow:10,20,15;
 }
 
-html, body { height: 100%; background: var(--bg-rice); color: #1A1D1F; }
+html, body {
+  height: 100%;
+  background: linear-gradient(135deg, var(--mist), var(--bg-rice));
+  color: #1A1D1F;
+}
 
 .glass{
-  background: rgba(255,255,255,.6);
-  backdrop-filter: blur(14px);
-  border:1px solid rgba(30,61,50,.08);
-  box-shadow:0 6px 24px rgba(var(--shadow),.08);
+  background: linear-gradient(to bottom right, rgba(255,255,255,.7), rgba(255,255,255,.4));
+  backdrop-filter: blur(16px);
+  border:1px solid rgba(30,61,50,.06);
+  box-shadow:0 8px 24px rgba(var(--shadow),.05);
 }
 
 .focus-ring:focus-visible{

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,37 +1,34 @@
-import Image from 'next/image';
 import Link from 'next/link';
 import type { Route } from 'next';
 
 export default function Hero(){
   return (
-    <section className="relative pt-28 pb-16">
-      <div className="absolute inset-0 -z-10">
-        <Image src="/hero.svg" alt="" fill priority className="object-cover opacity-80"/>
-      </div>
-      <div className="mx-auto max-w-[1200px] px-6 grid md:grid-cols-2 items-center gap-10">
+    <section className="relative isolate overflow-hidden pt-40 pb-24">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-mist/60 via-transparent to-rice" />
+      <div className="mx-auto max-w-[1200px] px-6 grid md:grid-cols-2 items-center gap-16">
         <div>
-          <h1 className="font-serif text-5xl md:text-6xl leading-tight text-gyokuro">Ceremonial-grade performance, at scale.</h1>
-          <p className="mt-4 text-lg text-black/70 max-w-[48ch]">Matcha for cafes, hotels, and craft kitchens—sourced with precision, stone-milled with care.</p>
-          <div className="mt-8 flex gap-3">
-            <Link href={'/request-access' as Route} className="px-5 py-3 rounded-xl bg-ceremonial text-white shadow-soft">Request access</Link>
-            <Link href="/catalog" className="px-5 py-3 rounded-xl border border-black/10 bg-white shadow-soft">View catalog</Link>
+          <h1 className="font-serif text-6xl md:text-7xl leading-tight text-gyokuro">Ceremonial-grade performance, at scale.</h1>
+          <p className="mt-6 text-lg text-black/70 max-w-[48ch]">Matcha for cafes, hotels, and craft kitchens—sourced with precision, stone-milled with care.</p>
+          <div className="mt-10 flex gap-4">
+            <Link href={'/request-access' as Route} className="px-6 py-3 rounded-xl bg-ceremonial text-white shadow-soft">Request access</Link>
+            <Link href="/catalog" className="px-6 py-3 rounded-xl border border-black/10 bg-white/80 backdrop-blur-sm shadow-soft">View catalog</Link>
           </div>
-          <ul className="mt-8 grid grid-cols-3 gap-6 text-sm text-black/70">
+          <ul className="mt-12 grid grid-cols-3 gap-8 text-sm text-black/70">
             <li><span className="block text-gyokuro font-medium">Stable supply</span>Year-round contracted lots.</li>
             <li><span className="block text-gyokuro font-medium">Effortless ordering</span>Quick reorders & CSV upload.</li>
             <li><span className="block text-gyokuro font-medium">Transparent pricing</span>Clear tiers & MOQs.</li>
           </ul>
         </div>
-        <div className="rounded-3xl glass p-8">
+        <div className="rounded-3xl glass p-10">
           <h3 className="font-medium text-ink">Sample Kit</h3>
           <p className="text-sm text-black/70 mt-1">Assess our grades before committing. Ships in 48h.</p>
-          <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+          <dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
             <div><dt className="text-black/50">Includes</dt><dd>3×30g tins</dd></div>
             <div><dt className="text-black/50">MOQ</dt><dd>1 kit</dd></div>
             <div><dt className="text-black/50">Lead time</dt><dd>2–4 days</dd></div>
             <div><dt className="text-black/50">HS code</dt><dd>0902.10</dd></div>
           </dl>
-          <a href="/samples" className="mt-6 inline-block px-4 py-2 rounded-lg bg-gyokuro text-white">Order sample kit</a>
+          <a href="/samples" className="mt-8 inline-block px-5 py-3 rounded-lg bg-gyokuro text-white">Order sample kit</a>
         </div>
       </div>
     </section>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -14,16 +14,16 @@ export default function Nav(){
 
   return (
     <header className={`fixed inset-x-0 top-0 z-50 transition ${scrolled ? 'glass' : 'bg-transparent'}`}>
-      <div className="mx-auto max-w-[1200px] px-6 py-3 flex items-center justify-between">
+      <div className="mx-auto max-w-[1200px] px-8 py-4 flex items-center justify-between">
         <Link href="/" className="font-serif text-xl">Yūzen Matcha</Link>
-        <nav className="hidden md:flex gap-8 text-sm">
+        <nav className="hidden md:flex gap-10 text-sm">
           <Link className="opacity-80 hover:opacity-100" href="/catalog">Catalog</Link>
           <Link className="opacity-80 hover:opacity-100" href="/pricing">Pricing</Link>
           <Link className="opacity-80 hover:opacity-100" href="/how-it-works">How it works</Link>
         </nav>
         <div className="flex items-center gap-4">
           <Link className="text-sm opacity-80 hover:opacity-100" href={'/signin' as Route}>Sign in</Link>
-          <Link className="px-3 py-2 rounded-full bg-ceremonial text-white text-sm focus-ring" href={'/request-access' as Route}>Request access</Link>
+          <Link className="px-4 py-2 rounded-full bg-ceremonial text-white text-sm focus-ring" href={'/request-access' as Route}>Request access</Link>
         </div>
       </div>
     </header>

--- a/components/PricingTable.tsx
+++ b/components/PricingTable.tsx
@@ -2,9 +2,9 @@ type Row = { qty: string; unit: string; unitPrice: string; margin: string; leadT
 
 export default function PricingTable({ rows }: { rows: Row[] }){
   return (
-    <div className="overflow-x-auto rounded-2xl border border-black/5 bg-white shadow-soft">
+    <div className="overflow-x-auto rounded-2xl glass shadow-soft">
       <table className="w-full text-sm">
-        <thead className="bg-mist/50">
+        <thead className="bg-mist/30">
           <tr className="[&>th]:text-left [&>th]:py-3 [&>th]:px-4">
             <th>Qty Break</th><th className="text-right">Unit</th><th className="text-right">Unit Price</th><th className="text-right">Est. Margin</th><th>Lead Time</th>
           </tr>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -9,19 +9,19 @@ export type Product = {
 
 export default function ProductCard({ product }: { product: Product }){
   return (
-    <article className="rounded-2xl border border-black/5 bg-white p-5 shadow-sm hover:shadow-md transition">
+    <article className="rounded-2xl glass p-6 transition hover:shadow-soft">
       <div className="flex items-start justify-between">
         <h3 className="font-medium">{product.name} | SKU {product.sku}</h3>
-        <span className="text-[11px] rounded-full px-2 py-1 bg-mist">MOQ {product.moq}</span>
+        <span className="text-[11px] rounded-full px-2 py-1 bg-mist/50">MOQ {product.moq}</span>
       </div>
-      <p className="mt-1 text-sm text-black/70">{product.blurb}</p>
-      <dl className="mt-3 grid grid-cols-3 gap-3 text-[13px]">
+      <p className="mt-2 text-sm text-black/70">{product.blurb}</p>
+      <dl className="mt-4 grid grid-cols-3 gap-4 text-[13px]">
         {product.tiers.map((t,i)=>(
           <div key={i}><dt className="text-black/50">{t.label}</dt><dd>{t.price}</dd></div>
         ))}
       </dl>
-      <div className="mt-4 flex gap-3">
-        <button className="px-3 py-2 rounded-lg border focus-ring">Add to Quote</button>
+      <div className="mt-5 flex gap-3">
+        <button className="px-3 py-2 rounded-lg border border-black/10 bg-white/60 backdrop-blur-sm focus-ring">Add to Quote</button>
         <button className="px-3 py-2 rounded-lg bg-ceremonial text-white focus-ring">Quick Add</button>
       </div>
     </article>


### PR DESCRIPTION
## Summary
- Introduce a light gradient background and modernize the reusable glass effect for transparent surfaces
- Expand navigation spacing for a cleaner header
- Redesign hero and product sections with generous whitespace and translucent cards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62719d3a08326a413a0c5f3ac62f4